### PR TITLE
Add support for levels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 			},
 			"devDependencies": {
 				"@types/node": "^17.0.36",
-				"src-ts": "^1.0.2",
+				"src-ts": "^1.0.3",
 				"ts-node-dev": "^2.0.0",
 				"typescript": "^4.7.2"
 			}
@@ -1259,9 +1259,9 @@
 			}
 		},
 		"node_modules/src-ts": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/src-ts/-/src-ts-1.0.2.tgz",
-			"integrity": "sha512-jbQgzZBV9zqHIXZ79AGG7g44tE4ftZE5HlQNJEe4PE7CLxnQJywaKKi48K/T6rsCyUfBwPTLYYBdsTmeik9pPQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/src-ts/-/src-ts-1.0.3.tgz",
+			"integrity": "sha512-Nn6mJihvjlo7AUjc7T/08ODZP/D51Zs6NX0D+LN5nJccAlFKLXXhhK1Lo7BwQMsNFi0Yz15ek5YP7fAfK62xrQ==",
 			"dev": true
 		},
 		"node_modules/string-width": {
@@ -2659,9 +2659,9 @@
 			"integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
 		},
 		"src-ts": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/src-ts/-/src-ts-1.0.2.tgz",
-			"integrity": "sha512-jbQgzZBV9zqHIXZ79AGG7g44tE4ftZE5HlQNJEe4PE7CLxnQJywaKKi48K/T6rsCyUfBwPTLYYBdsTmeik9pPQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/src-ts/-/src-ts-1.0.3.tgz",
+			"integrity": "sha512-Nn6mJihvjlo7AUjc7T/08ODZP/D51Zs6NX0D+LN5nJccAlFKLXXhhK1Lo7BwQMsNFi0Yz15ek5YP7fAfK62xrQ==",
 			"dev": true
 		},
 		"string-width": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^17.0.36",
-		"src-ts": "^1.0.2",
+		"src-ts": "^1.0.3",
 		"ts-node-dev": "^2.0.0",
 		"typescript": "^4.7.2"
 	}

--- a/src/db/models/Leaderboard.model.ts
+++ b/src/db/models/Leaderboard.model.ts
@@ -19,6 +19,10 @@ export class Leaderboard {
 	@Column()
 	category_id!: string;
 
+	/** The ID of the level of the leaderboard. If null, then this is full-game. */
+	@Column({ nullable: true })
+	level_id?: string;
+
 	/** The last known name of the associated leaderboard. */
 	@Column()
 	lb_name!: string;

--- a/src/db/models/Leaderboard.model.ts
+++ b/src/db/models/Leaderboard.model.ts
@@ -35,17 +35,18 @@ export class Leaderboard {
 	@OneToMany(() => TrackedLeaderboard, tlb => tlb.leaderboard, { cascade: true })
 	trackedLeaderboards!: TrackedLeaderboard[];
 
-	constructor(game_id: string, category_id: string, lb_name: string) {
+	constructor(game_id: string, category_id: string, lb_name: string, level_id?: string) {
 		this.game_id = game_id;
 		this.category_id = category_id;
 		this.lb_name = lb_name;
+		this.level_id = level_id;
 	}
 
-	static async exists(game_id: string, category_id: string, variables: [Variable, string][]) {
+	static async exists(game_id: string, category_id: string, variables: [Variable, string][], level_id?: string) {
 		const lRepo = DB.getRepository(Leaderboard);
 		
 		// check leaderboard with same game/cat exists (multiple may)
-		const possibles = await lRepo.find({ where: { game_id, category_id }, relations: { variables: true, trackedLeaderboards: true } });
+		const possibles = await lRepo.find({ where: { game_id, category_id, level_id }, relations: { variables: true, trackedLeaderboards: true } });
 
 		// check to see if any have all variables match
 		return possibles.find(board => board.variables.every(

--- a/src/discord/commands/leaderboard/lb.add.ts
+++ b/src/discord/commands/leaderboard/lb.add.ts
@@ -61,7 +61,7 @@ export async function add(interaction: CommandInteraction) {
 
 	// build leaderboard name
 	const labels = variables.map(([subcat, v]) => subcat.values.values[v].label);
-	const lb_name = SRC.buildLeaderboardName(gameObj.names.international, category.name, labels);
+	const lb_name = SRC.buildLeaderboardName(gameObj.names.international, category.name, labels, level?.name);
 
 	// here we should check for dupes
 	let board = await Leaderboard.exists(gameObj.id, category.id, variables);

--- a/src/discord/commands/leaderboard/lb.add.ts
+++ b/src/discord/commands/leaderboard/lb.add.ts
@@ -84,6 +84,17 @@ export async function add(interaction: CommandInteraction) {
 	interaction.editReply({ content: `Added the leaderboard ${lb_name}.`, components: [] });
 }
 
+async function selectType(interaction: CommandInteraction): Promise<CategoryType> {
+	const menu = buildMenu([{ value: 'per-game', label: "Full-game" }, { value: 'per-level', label: "Level" }], 'isLevel');
+	const [message, choiceInt] = await sendMenu(interaction, `Is the leaderboard a full-game or level category?`, [ menu ]);
+	const choice = getResponse(choiceInt) as CategoryType;
+
+	await interaction.editReply({ content: `Selected ${choice}...`, components: [] });
+	await message.delete();
+
+	return choice;
+}
+
 async function selectCategory(interaction: CommandInteraction, game: Game): Promise<Category> {
 	// Get category from menu
 	const catData = game.categories!.data;

--- a/src/discord/commands/leaderboard/lb.add.ts
+++ b/src/discord/commands/leaderboard/lb.add.ts
@@ -53,8 +53,7 @@ export async function add(interaction: CommandInteraction) {
 	// get leaderboard info from user
 	// choose if levels
 	const catType = await selectType(interaction);
-	let level: Level | undefined = undefined;
-	if(catType === 'per-level') level = await selectLevel(interaction, gameObj);
+	const level = catType === 'per-level' ? await selectLevel(interaction, gameObj) : undefined;
 
 	const category = await selectCategory(interaction, gameObj, catType);
 	const variables = await selectVariables(interaction, category, level);

--- a/src/discord/commands/leaderboard/lb.add.ts
+++ b/src/discord/commands/leaderboard/lb.add.ts
@@ -4,7 +4,7 @@ import { GuildEntity, Leaderboard, TrackedLeaderboard, Variable as VariableEntit
 import UserError from "../../UserError";
 import * as SRC from '../../../speedruncom';
 import { buildMenu, getResponse, sendMenu } from "../../util";
-import { Category, Game, Variable } from "src-ts";
+import { Category, CategoryType, Game, Variable } from "src-ts";
 
 const gameRegex = /^\w+$/;
 
@@ -51,7 +51,10 @@ export async function add(interaction: CommandInteraction) {
 	if(SRC.isError(gameObj)) throw new UserError(`Game ${gameOpt} does not exist.`);
 
 	// get leaderboard info from user
-	const category = await selectCategory(interaction, gameObj);
+	// choose if levels
+	const catType = await selectType(interaction);
+
+	const category = await selectCategory(interaction, gameObj, catType);
 	const variables = await selectVariables(interaction, category);
 
 	// build leaderboard name
@@ -95,12 +98,12 @@ async function selectType(interaction: CommandInteraction): Promise<CategoryType
 	return choice;
 }
 
-async function selectCategory(interaction: CommandInteraction, game: Game): Promise<Category> {
+async function selectCategory(interaction: CommandInteraction, game: Game, type: CategoryType): Promise<Category> {
 	// Get category from menu
 	const catData = game.categories!.data;
 
 	// Make category menu to get the category of the leaderboard
-	const catNames = catData.map(cat => ({ value: cat.id, label: cat.name }));
+	const catNames = catData.filter(cat => cat.type === type).map(cat => ({ value: cat.id, label: cat.name }));
 	const menu = buildMenu(catNames, game.id);
 	const [message, choiceInt] = await sendMenu(interaction, `Choose a category:`, [ menu ]);
 	let categoryId = getResponse(choiceInt);

--- a/src/discord/commands/leaderboard/lb.add.ts
+++ b/src/discord/commands/leaderboard/lb.add.ts
@@ -63,7 +63,7 @@ export async function add(interaction: CommandInteraction) {
 	const lb_name = SRC.buildLeaderboardName(gameObj.names.international, category.name, labels, level?.name);
 
 	// here we should check for dupes
-	let board = await Leaderboard.exists(gameObj.id, category.id, variables);
+	let board = await Leaderboard.exists(gameObj.id, category.id, variables, level?.id);
 	if(board && board.trackedLeaderboards.find(tlb => tlb.guild_id === interaction.guildId && tlb.lb_id === board!.lb_id))
 	{
 		throw new UserError(`This guild is already tracking the leaderboard ${lb_name}.`);
@@ -78,7 +78,7 @@ export async function add(interaction: CommandInteraction) {
 
 	// save new leaderboard in database
 	if(!board) {
-		board = new Leaderboard(gameObj.id, category.id, lb_name);
+		board = new Leaderboard(gameObj.id, category.id, lb_name, level?.id);
 		board.variables = variables.map(([subcat, v]) => new VariableEntity(board!, subcat.id, v));	
 		board.trackedLeaderboards = [];
 	}

--- a/src/discord/commands/update.command.ts
+++ b/src/discord/commands/update.command.ts
@@ -57,7 +57,10 @@ export const execute = async (interaction: CommandInteraction) => {
 			}));
 
 			// get all sr.c player ids
-			const lb = await SRC.getLeaderboard(tlb.leaderboard.game_id, tlb.leaderboard.category_id, { top: 1, ...variables });
+			const lbOptions = { top: 1, ...variables };
+			const lb = tlb.leaderboard.level_id
+				? await SRC.getLevelLeaderboard(tlb.leaderboard.game_id, tlb.leaderboard.level_id, tlb.leaderboard.category_id, lbOptions)
+				: await SRC.getLeaderboard(tlb.leaderboard.game_id, tlb.leaderboard.category_id, lbOptions);
 			if(SRC.isError(lb)) throw new UserError(`Error updating ${tlb.leaderboard.lb_name}`);
 
 			// guests are ignored

--- a/src/speedruncom/index.ts
+++ b/src/speedruncom/index.ts
@@ -19,8 +19,11 @@ export * from './game';
 export * from './category';
 export * from './leaderboard';
 
-export function buildLeaderboardName(gameName: string, categoryName: string, variables: string[]) {
-	let name = `${gameName} - ${categoryName}`;
+export function buildLeaderboardName(gameName: string, categoryName: string, variables: string[], levelName?: string) {
+	let name = `${gameName}`;
+	if(levelName) name += `: ${levelName}`;
+	name += ` - ${categoryName}`;
+	
 	if(variables.length !== 0)
 	{
 		name += ` (${variables.join(', ')})`;

--- a/src/speedruncom/leaderboard.ts
+++ b/src/speedruncom/leaderboard.ts
@@ -1,9 +1,17 @@
-import { LeaderboardResponse, Error, LeaderboardParams, Leaderboard } from 'src-ts';
+import { LeaderboardResponse, Error, LeaderboardParams, Leaderboard, LeaderboardLevelResponse, LeaderboardLevelParams } from 'src-ts';
 import * as SRC from '.';
 
 /** Get the User data from a username or id */
 export async function getLeaderboard(game: string, category: string, options?: LeaderboardParams): Promise<Leaderboard | Error> {
 	const res = await SRC.get<LeaderboardResponse>(`/leaderboards/${game}/category/${category}`, options);
+
+	if('status' in res) return res;
+
+	return res.data;
+}
+
+export async function getLevelLeaderboard(game: string, level: string, category: string, options?: LeaderboardLevelParams): Promise<Leaderboard | Error> {
+	const res = await SRC.get<LeaderboardLevelResponse>(`/leaderboards/${game}/level/${level}/${category}`, options);
 
 	if('status' in res) return res;
 

--- a/srcwrsbot.drawio
+++ b/srcwrsbot.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="R2lEEEUBdFMjLlhIrx00" name="Page-1">
-        <mxGraphModel dx="804" dy="155" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" background="none" math="0" shadow="0" extFonts="Permanent Marker^https://fonts.googleapis.com/css?family=Permanent+Marker">
+        <mxGraphModel dx="1091" dy="404" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" background="none" math="0" shadow="0" extFonts="Permanent Marker^https://fonts.googleapis.com/css?family=Permanent+Marker">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -8,7 +8,7 @@
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
                 <mxCell id="C-vyLk0tnHw3VtMMgP7b-2" value="Leaderboard" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;" parent="1" vertex="1">
-                    <mxGeometry x="470" y="210" width="130" height="150" as="geometry"/>
+                    <mxGeometry x="470" y="210" width="130" height="180" as="geometry"/>
                 </mxCell>
                 <mxCell id="C-vyLk0tnHw3VtMMgP7b-3" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" parent="C-vyLk0tnHw3VtMMgP7b-2" vertex="1">
                     <mxGeometry y="30" width="130" height="30" as="geometry"/>
@@ -49,8 +49,21 @@
                         <mxRectangle width="100" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="14" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="C-vyLk0tnHw3VtMMgP7b-2" vertex="1">
+                <mxCell id="20" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="C-vyLk0tnHw3VtMMgP7b-2">
                     <mxGeometry y="120" width="130" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="21" value="?" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;" vertex="1" parent="20">
+                    <mxGeometry width="30" height="30" as="geometry">
+                        <mxRectangle width="30" height="30" as="alternateBounds"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="22" value="level_id" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;" vertex="1" parent="20">
+                    <mxGeometry x="30" width="100" height="30" as="geometry">
+                        <mxRectangle width="100" height="30" as="alternateBounds"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="14" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="C-vyLk0tnHw3VtMMgP7b-2" vertex="1">
+                    <mxGeometry y="150" width="130" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="15" value="" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;" parent="14" vertex="1">
                     <mxGeometry width="30" height="30" as="geometry">
@@ -133,15 +146,15 @@
                         <mxRectangle width="120" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="17" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="9HkofyLX8LU-IOiNh58f-10">
+                <mxCell id="17" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="9HkofyLX8LU-IOiNh58f-10" vertex="1">
                     <mxGeometry y="90" width="150" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="18" value="" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;" vertex="1" parent="17">
+                <mxCell id="18" value="" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;" parent="17" vertex="1">
                     <mxGeometry width="30" height="30" as="geometry">
                         <mxRectangle width="30" height="30" as="alternateBounds"/>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="19" value="src_name" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;" vertex="1" parent="17">
+                <mxCell id="19" value="src_name" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;" parent="17" vertex="1">
                     <mxGeometry x="30" width="120" height="30" as="geometry">
                         <mxRectangle width="120" height="30" as="alternateBounds"/>
                     </mxGeometry>


### PR DESCRIPTION
Adds support for level leaderboards, including:
- Extra menu on /leaderboard add asking for category type (full-game or level)
- Menu for selecting level
- Menus for categories/variables for level leaderboards are correctly filtered
- /update will recognise and account for levels, as well as other locations in which leaderboards are referenced.